### PR TITLE
Fix for some versions of Node

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,9 @@ Forecast.prototype.get = function(apiParams, ignoreCache, callback) {
   }
 
   var Service = this.providers[this.options.service.toLowerCase()];
+  if (Service instanceof Object) {
+    Service = Service[this.options.service.toLowerCase()];
+  }
   var service = new Service(this.options);
 
   service.get(apiParams, function(err, result) {


### PR DESCRIPTION
On some versions of Node (specifically inside official Docker images) an object is sent back when loading the service. This fixes that without breaking functionality.
